### PR TITLE
Prevent browsers that use backspace to navigate to previous page

### DIFF
--- a/scripts/terminal.ts
+++ b/scripts/terminal.ts
@@ -74,6 +74,7 @@ export const readLine = () => {
 				writeLineBreak();
 				resolve(line);
 			} else if (key === backspaceKey && line.length > 0) {
+        event.preventDefault();
 				line = line.slice(0, line.length - 1);
 				removeLastChar();
 			}


### PR DESCRIPTION
Browsers that use backspace to navigate to the previous page won't go back when preventing the default event.

#5 