### PR TITLE
fix: ignore the Alt key

### DIFF
--- a/client/src/typing-panel.ts
+++ b/client/src/typing-panel.ts
@@ -63,6 +63,7 @@ export class TypingPanel extends HTMLElement {
 
   private processChar(char: string) {
     if (char === "Shift") return;
+    if (char === "Alt") return;
 
     if (char === "Backspace") {
       if (this.index === 0) return;


### PR DESCRIPTION
On e.g. the German keyboard layout, you need the Alt key for some relevant keys. 

At least on macOS, I think it is Alt + Ctrl (Alt Gr) on a German Windows keyboard layout, but I cannot test this unfortunately and don't want to add code I cannot test 

Example key combinations on the German layout that use the <kbd>Alt</kbd> key.

- <kbd>Alt</kbd> + <kbd>5</kbd> -> <kbd>[</kbd>
- <kbd>Alt</kbd> + <kbd>6</kbd> -> <kbd>]</kbd>
- <kbd>Alt</kbd> + <kbd>7</kbd> -> <kbd>|</kbd>
- <kbd>Alt</kbd> + <kbd>8</kbd> -> <kbd>{</kbd>
- <kbd>Alt</kbd> + <kbd>9</kbd> -> <kbd>}</kbd>

Those are important in programming and to complete the typing tests ;-) 